### PR TITLE
[#15] Displaying total indexed orgs and repos number at home

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,14 +1,5 @@
 /* This file is for your main application css. */
 
-.container-org-header .org-avatar {
-    width: 200px;
-    border: solid 1px white;
-}
-
-.container-org-header .org-description {
-    color: #777777;
-}
-
 body {
     padding-top: 85px;
     background-color: white;
@@ -128,4 +119,20 @@ a.card-fork {
 
 .coop-list-item .org-location span {
     font-size: .9em;
+}
+
+@media (min-width: 300px) {
+    .counter-box {
+        transform: scale(0.7);
+    }
+}
+@media (min-width: 600px) {
+    .counter-box {
+        transform: scale(0.9);
+    }
+}
+@media (min-width: 800px) {
+    .counter-box {
+        transform: scale(1);
+    }
 }

--- a/assets/js/components/OrgHeader.tsx
+++ b/assets/js/components/OrgHeader.tsx
@@ -12,48 +12,47 @@ const OrgHeader:React.FC<{org: Org, maxLanguages: number, starsSum: number}> = (
     
     return (
         
-        <Container>
-            <div className="title-box text-center mt-5 org-header">
-                <Row>
-                    <Container className="col-1">
-                        <div className="counter-box counter-box mt-5">
-                            <div className="counter-ico">
-                                <span className="ico-circle"><GoStar/></span>
-                            </div>
-                            <div className="counter-num" >
-                                <p className="counter"><CountUp end={starsSum}/></p>
-                                <span className="counter-text">STARS</span>
-                            </div>
+        <Container className="mt-5">
+            <Row>
+                <Container className="col-2">
+                    <div className="counter-box mt-5">
+                        <div className="counter-ico">
+                            <span className="ico-circle"><GoStar/></span>
                         </div>
-                    </Container>
-                    <Container className="col-10">
-                        <img src={org.avatar_url} alt="" className="center-block rounded-circle b-shadow-a avatar_coop"/>
-                        <h3 className="title-a mt-4">
-                        {org.yml_data.name}
-                        </h3>
-                        <p className="subtitle-a">
-                        {org.description}
-                        </p>
-                    </Container>
-                    <Container className="col-1">
-                        <div className="counter-box counter-box mt-5">
-                            <div className="counter-ico">
-                                <span className="ico-circle"><GoCode/></span>
-                            </div>
-                            <div className="counter-num" >
-                                <p className="counter"><CountUp end={org.repo_count}/></p>
-                                <span className="counter-text">REPOS</span>
-                            </div>
+                        <div className="counter-num" >
+                            <p className="counter"><CountUp end={starsSum}/></p>
+                            <span className="counter-text">STARS</span>
                         </div>
-                    </Container>
-                </Row>
-                
-                <div className="line-mf mb-3"/>
-                <div className="skill-mf">
-                    <Row>
-                        <LanguagesProgressBar languages={org.languages} maxLanguages={maxLanguages}></LanguagesProgressBar>
-                    </Row>
-                </div>
+                    </div>
+                </Container>
+                <Container className="col-8 text-center mb-0">
+                    <img src={org.avatar_url} alt="" className="center-block rounded-circle b-shadow-a avatar_coop"/>
+                    <h3 className="title-a mt-4">
+                    {org.yml_data.name}
+                    </h3>
+                    <p className="subtitle-a">
+                    {org.description}
+                    </p>
+                </Container>
+                <Container className="col-2">
+                    <div className="counter-box mt-5">
+                        <div className="counter-ico">
+                            <span className="ico-circle"><GoCode/></span>
+                        </div>
+                        <div className="counter-num" >
+                            <p className="counter"><CountUp end={org.repo_count}/></p>
+                            <span className="counter-text">REPOS</span>
+                        </div>
+                    </div>
+                </Container>
+            </Row>
+            
+            <div className="line-mf mb-3"/>
+            <Row className="skill-mf">
+                <LanguagesProgressBar languages={org.languages} maxLanguages={maxLanguages}></LanguagesProgressBar>
+            </Row>
+
+            <Container className="text-center mb-4">
                 <ButtonGroup>
                     {org.location &&
                         <span>
@@ -67,14 +66,14 @@ const OrgHeader:React.FC<{org: Org, maxLanguages: number, starsSum: number}> = (
                     }
                     {org.blog &&
                         <Button color="link" className="ml-4 pt-0">
-                            <CardLink href={org.blog} target='_blank'> 
+                            <CardLink href={org.blog} target="_blank"> 
                                 <GoLink/> { org.blog }
                             </CardLink>
                         </Button>
                     }
                     {org.login &&
                         <Button color="link" className="ml-4 pt-0">
-                            <CardLink href={`https://github.com/${org.login}`} target='_blank'> 
+                            <CardLink href={`https://github.com/${org.login}`} target="_blank"> 
                                 <GoMarkGithub/> { org.login }
                             </CardLink>
                         </Button>
@@ -84,18 +83,7 @@ const OrgHeader:React.FC<{org: Org, maxLanguages: number, starsSum: number}> = (
                         Created in {createdDate}
                     </span>
                 </ButtonGroup>
-                {/* <br/>
-                <p className="mt-2">
-                    <GitHubButton
-                        href={`https://github.com/${org.login}`}
-                        data-size="large"
-                        data-show-count
-                        aria-label={`Follow @${org.login} on GitHub`}
-                    >
-                        Follow @{org.login}
-                    </GitHubButton>
-                </p> */}
-            </div>
+            </Container>
         </Container>
 
     );

--- a/assets/js/pages/index.tsx
+++ b/assets/js/pages/index.tsx
@@ -3,13 +3,16 @@ import {Suspense} from 'react';
 import {RouteComponentProps, Link} from 'react-router-dom';
 import {CardDeck, Card, CardHeader, CardBody, Container, Row, Button} from "reactstrap";
 import useFetch from 'fetch-suspense';
-import {ApiResponse, Repo, TotalLanguage, Topic} from "../types";
+import {ApiResponse, Repo, Counters, TotalLanguage, Topic} from "../types";
 import RepoCard from "../components/RepoCard";
 import FullWidthSpinner from "../components/FullWidthSpinner";
 import LanguagesChart from '../components/LanguagesChart';
 import _ from "lodash";
 import getLangColor from '../languageColors';
+import CountUp from 'react-countup';
+import {GoGlobe, GoCode} from "react-icons/all";
 
+type CountersResponse = ApiResponse<Counters>;
 type LanguagesResponse = ApiResponse<[TotalLanguage]>;
 type ReposResponse = ApiResponse<[Repo]>
 type TopicsResponse = ApiResponse<[Topic]>
@@ -26,24 +29,46 @@ const RepoList: React.FC<urlProp> = ({url}) => {
 };
 
 
-const HomePage: React.FC<RouteComponentProps> = ({history}) => {
+const HomePage: React.FC<RouteComponentProps> = () => {
+    const countersResponse = useFetch("/api/counters") as CountersResponse;
     const languagesResponse = useFetch("/api/languages") as LanguagesResponse;
     const topics = useFetch("/api/topics") as TopicsResponse;
-    const navigate = (url: string) =>{
-        history.push(url);
-    };
 
     return <>
-        <Container className="pt-xl-5">
-            <div className="title-box text-center">
-                <h3 className="title-a">
-                Popular Repos
-                </h3>
-                <p className="subtitle-a">
-                Most popular repos from coops
-                </p>
-                <div className="line-mf"/>
-            </div>
+        <Container className="mt-5">
+            <Row>
+                <Container className="col-2 mt-2">
+                    <div className="counter-box">
+                        <div className="counter-ico">
+                            <span className="ico-circle"><GoGlobe/></span>
+                        </div>
+                        <div className="counter-num">
+                            <p className="counter"><CountUp end={countersResponse.data.orgs}/></p>
+                            <span className="counter-text">COOPS</span>
+                        </div>
+                    </div>
+                </Container>
+                <Container className="col-8 title-box text-center">
+                    <h3 className="title-a">
+                    Popular Repos
+                    </h3>
+                    <p className="subtitle-a">
+                    Most popular repos from coops
+                    </p>
+                    <div className="line-mf"/>
+                </Container>
+                <Container className="col-2 mt-2">
+                    <div className="counter-box">
+                        <div className="counter-ico">
+                            <span className="ico-circle"><GoCode/></span>
+                        </div>
+                        <div className="counter-num">
+                            <p className="counter"><CountUp end={countersResponse.data.repos}/></p>
+                            <span className="counter-text">REPOS</span>
+                        </div>
+                    </div>
+                </Container>
+            </Row>
             <Suspense fallback={<FullWidthSpinner/>}>
                 <RepoList url={"/api/repos?limit=6&sort=popular&exclude_forks=true"}/>
             </Suspense>

--- a/assets/js/pages/languageRepos.tsx
+++ b/assets/js/pages/languageRepos.tsx
@@ -37,7 +37,7 @@ const LanguageReposPage: React.FC<RouteComponentProps<MatchParams>> = ({match}) 
   const repos = languageRepos(lang);
 
   return <>
-    <Container className="pt-xl-5 result-repos-cards">
+    <Container className="pt-md-5 result-repos-cards">
         <div className="title-box text-center">
             <h3 className="title-a">
                 {lang} repos

--- a/assets/js/pages/org.tsx
+++ b/assets/js/pages/org.tsx
@@ -27,7 +27,7 @@ const OrgPage: React.FC<RouteComponentProps<MatchParams>> = ({match}) => {
 
     return <>
         <OrgHeader org={org} maxLanguages={maxLanguages} starsSum={starsSum}/>
-        <Container className="org-repos-cards">
+        <Container className="org-repos-cards mt-5">
             {_.chunk(repos.data, 3).map((row, i)=>
             <CardDeck key={i}>
                 {row.map((repo, j)=><RepoCard repo={repo} key={i*10+j}/>)}

--- a/assets/js/pages/searchResults.tsx
+++ b/assets/js/pages/searchResults.tsx
@@ -41,7 +41,7 @@ const SearchResultsPage: React.FC<RouteComponentProps> = () => {
   const repos = searchRepos(search);
 
   return <>
-    <Container className="pt-xl-5 result-repos-cards">
+    <Container className="pt-md-5 result-repos-cards">
         <div className="title-box text-center">
             <h3 className="title-a">
                 Search results

--- a/assets/js/pages/topics.tsx
+++ b/assets/js/pages/topics.tsx
@@ -22,7 +22,7 @@ const TopicsPage: React.FC<RouteComponentProps<MatchParams>> = ({match}) => {
     const repos = searchRepos(topic);
 
     return <>
-        <Container className="pt-xl-5">
+        <Container className="pt-md-5 result-repos-cards">
             <div className="title-box text-center">
                 <h3 className="title-a">
                     {topic} Repos

--- a/assets/js/types.ts
+++ b/assets/js/types.ts
@@ -50,6 +50,11 @@ export type Org = {
     repo_count: number;
 }
 
+export type Counters = {
+    orgs: number;
+    repos: number;
+};
+
 export type Topic = {
     topic: string;
     count: number;

--- a/lib/coophub/repos.ex
+++ b/lib/coophub/repos.ex
@@ -121,6 +121,23 @@ defmodule Coophub.Repos do
     end
   end
 
+  @spec get_counters() :: map | :error
+  def get_counters() do
+    case get_all_orgs() do
+      orgs when is_map(orgs) ->
+        orgs
+        |> Map.values()
+        |> Enum.reduce(%{"orgs" => 0, "repos" => 0}, fn org, acc ->
+          acc
+          |> Map.put("orgs", acc["orgs"] + 1)
+          |> Map.put("repos", acc["repos"] + org["repo_count"])
+        end)
+
+      err ->
+        err
+    end
+  end
+
   @spec get_topics() :: [map] | :error
   def get_topics() do
     case get_all_repos() do

--- a/lib/coophub_web/controllers/repo_controller.ex
+++ b/lib/coophub_web/controllers/repo_controller.ex
@@ -72,6 +72,18 @@ defmodule CoophubWeb.RepoController do
     end
   end
 
+  def counters(conn, _params) do
+    fallback_mfa = {Repos, :get_counters, []}
+
+    case maybe_get_response_from_cache(conn, fallback_mfa) do
+      {status, counters} when status in @uris_cache_success ->
+        render(conn, "counters.json", counters: counters)
+
+      _ ->
+        render_status(conn, 500)
+    end
+  end
+
   def topics(conn, _params) do
     fallback_mfa = {Repos, :get_topics, []}
 

--- a/lib/coophub_web/router.ex
+++ b/lib/coophub_web/router.ex
@@ -20,6 +20,7 @@ defmodule CoophubWeb.Router do
     get "/orgs/:name", RepoController, :org
     get "/orgs/:name/repos", RepoController, :org_repos
     get "/repos", RepoController, :repos
+    get "/counters", RepoController, :counters
     get "/topics", RepoController, :topics
     get "/search", RepoController, :search
     get "/languages", RepoController, :languages

--- a/lib/coophub_web/views/repo_view.ex
+++ b/lib/coophub_web/views/repo_view.ex
@@ -13,6 +13,10 @@ defmodule CoophubWeb.RepoView do
     %{data: repos}
   end
 
+  def render("counters.json", %{counters: counters}) do
+    %{data: counters}
+  end
+
   def render("topics.json", %{topics: topics}) do
     %{data: topics}
   end

--- a/test/coophub/repos_test.exs
+++ b/test/coophub/repos_test.exs
@@ -40,6 +40,12 @@ defmodule Coophub.ReposTest do
     end
   end
 
+  describe "get_counters/0" do
+    test "returns the counters for orgs and repos" do
+      assert Repos.get_counters() == %{"orgs" => 2, "repos" => 5}
+    end
+  end
+
   describe "search/2" do
     test "returns an empty list when no repos match a single term" do
       repos = Repos.search("will-not-match")

--- a/test/coophub_web/controllers/repo_controller_test.exs
+++ b/test/coophub_web/controllers/repo_controller_test.exs
@@ -195,6 +195,12 @@ defmodule CoophubWeb.RepoControllerTest do
     end
   end
 
+  describe "GET /api/counters" do
+    test "get the counters for orgs and repos", %{conn: conn} do
+      assert get_data(conn, :counters) == %{"orgs" => 2, "repos" => 5}
+    end
+  end
+
   describe "GET /api/topics" do
     test "lists all topics", %{conn: conn} do
       data = get_data(conn, :topics)

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -15,6 +15,7 @@ defmodule CoophubWeb.Fixtures do
       {"fiqus",
        %{
          "repos" => generate_repos(:fiqus),
+         "repo_count" => 2,
          "languages" => generate_languages(:surgex),
          "login" => "fiqus",
          "id" => 1_891_317,
@@ -52,6 +53,7 @@ defmodule CoophubWeb.Fixtures do
       {"test",
        %{
          "repos" => generate_repos(:test),
+         "repo_count" => 3,
          "languages" => generate_languages(:testone),
          "login" => "test",
          "id" => 123,


### PR DESCRIPTION
This PR solves one task of #15:

* Added a new endpoint `/api/counters` that returns `%{"orgs" => x, "repos" => y}` with the total amount of indexed orgs and repos (memoized at controller level, as the other endpoints).
* Displaying them at home page, following the same style as org page.
* Did some additional UI fixes/improves, trying to correctly display the site in all screen sizes.