### PR TITLE
#58: Fixing languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 - GET api/repos (all coops repos)
 - GET api/search?q=term_to_search
 - GET api/topics (all the repos topics)
-- GET api/languages (all the programming languages with bytes and %)
+- GET api/languages (all the programming languages with percentages)
 - GET api/languages/:lang (the repos using the lang)
 
 ## Allowed query params

--- a/assets/js/components/LanguagesProgressBar.tsx
+++ b/assets/js/components/LanguagesProgressBar.tsx
@@ -4,7 +4,7 @@ import getLangColor from '../languageColors';
 
 const LanguagesProgressBar: React.FC<{ languages: Array<Language>, maxLanguages: number }> = ({ languages, maxLanguages }) => {
     let mainLanguages = languages.slice(0, maxLanguages);
-    mainLanguages.push({ bytes: 0, lang: "other", percentage: Math.round((100.0 - (mainLanguages.reduce((acc, lang) => acc + lang.percentage, 0))) * 100) / 100})
+    mainLanguages.push({ lang: "other", percentage: Math.round((100.0 - (mainLanguages.reduce((acc, lang) => acc + lang.percentage, 0))) * 100) / 100})
     mainLanguages = mainLanguages.filter(l=>l.percentage > 0);
 
     return <>

--- a/assets/js/types.ts
+++ b/assets/js/types.ts
@@ -9,13 +9,11 @@ export type Owner = {
 
 export type Language = {
     lang: string,
-    bytes: number,
     percentage: number
 }
 
 export type TotalLanguage = {
     [key: string]: {
-        bytes: number,
         percentage: number
     }
 }

--- a/lib/coophub/backends/backends.ex
+++ b/lib/coophub/backends/backends.ex
@@ -131,11 +131,6 @@ defmodule Coophub.Backends do
     end
   end
 
-  @spec get_org_languages(org) :: map()
-  def get_org_languages(org) do
-    Repos.get_org_languages(org)
-  end
-
   @spec request(String.t(), headers) :: {:ok, map | [map], integer} | {:error, any}
   defp request(nil, _), do: {:ok, [], 0}
 

--- a/lib/coophub/backends/github.ex
+++ b/lib/coophub/backends/github.ex
@@ -83,12 +83,21 @@ defmodule Coophub.Backends.Github do
   @impl Backends.Behaviour
   @spec parse_languages(langs) :: langs
   def parse_languages(languages) do
-    Repos.get_percentages_by_language(languages)
+    percentage_from_bytes(languages)
   end
 
   ########
   ## INTERNALS
   ########
+  defp percentage_from_bytes(languages) do
+    total = Enum.reduce(languages, 0, fn {_lang, bytes}, acc -> acc + bytes end)
+
+    Enum.reduce(languages, %{}, fn {lang, bytes}, acc ->
+      percentage_for_lang = (bytes * 100 / total) |> Float.round(2)
+      Map.put(acc, lang, %{"percentage" => percentage_for_lang})
+    end)
+  end
+
   defp prepare_request(name, path) do
     {name, full_url(path), headers()}
   end

--- a/lib/coophub/backends/gitlab.ex
+++ b/lib/coophub/backends/gitlab.ex
@@ -113,10 +113,7 @@ defmodule Coophub.Backends.Gitlab do
       def parse_languages(languages) do
         languages
         |> Enum.reduce(%{}, fn {lang, percentage}, acc ->
-          # bytes is not used by GitLab, since we are using bytes only for getting percentages
-          # using directly the percentage as bytes will be proportional
-          # (100 bytes will be the total of bytes of the project)
-          Map.put(acc, lang, %{"bytes" => percentage, "percentage" => percentage})
+          Map.put(acc, lang, %{"percentage" => percentage})
         end)
       end
 

--- a/lib/coophub/cache_warmer.ex
+++ b/lib/coophub/cache_warmer.ex
@@ -167,7 +167,7 @@ defmodule Coophub.CacheWarmer do
   end
 
   defp put_org_languages(org) do
-    Map.put(org, :languages, Backends.get_org_languages(org))
+    Map.put(org, :languages, Repos.get_org_languages(org))
     |> convert_languages_to_list_and_sort()
   end
 
@@ -187,7 +187,7 @@ defmodule Coophub.CacheWarmer do
       datamap
       |> Map.get(:languages, [])
       |> Enum.map(fn {lang, stats} -> Map.put(stats, "lang", lang) end)
-      |> Enum.sort(&(&1["bytes"] > &2["bytes"]))
+      |> Enum.sort(&(&1["percentage"] > &2["percentage"]))
 
     Map.put(datamap, :languages, languages)
   end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -433,27 +433,22 @@ defmodule CoophubWeb.Fixtures do
     [
       %{
         "lang" => "Elixir",
-        "bytes" => 142_649,
         "percentage" => 60.75
       },
       %{
         "lang" => "Vue",
-        "bytes" => 54487,
         "percentage" => 23.2
       },
       %{
         "lang" => "JavaScript",
-        "bytes" => 23030,
         "percentage" => 9.81
       },
       %{
         "lang" => "CSS",
-        "bytes" => 13607,
         "percentage" => 5.79
       },
       %{
         "lang" => "HTML",
-        "bytes" => 1050,
         "percentage" => 0.45
       }
     ]
@@ -463,7 +458,6 @@ defmodule CoophubWeb.Fixtures do
     [
       %{
         "lang" => "CSS",
-        "bytes" => 642,
         "percentage" => 100
       }
     ]
@@ -473,22 +467,18 @@ defmodule CoophubWeb.Fixtures do
     [
       %{
         "lang" => "Elixir",
-        "bytes" => 5_000,
         "percentage" => 50
       },
       %{
         "lang" => "Erlang",
-        "bytes" => 2_500,
         "percentage" => 25
       },
       %{
         "lang" => "JavaScript",
-        "bytes" => 1_500,
         "percentage" => 15
       },
       %{
         "lang" => "HTML",
-        "bytes" => 1_000,
         "percentage" => 10
       }
     ]
@@ -498,17 +488,14 @@ defmodule CoophubWeb.Fixtures do
     [
       %{
         "lang" => "Python",
-        "bytes" => 7_000,
         "percentage" => 70
       },
       %{
         "lang" => "HTML",
-        "bytes" => 2_000,
         "percentage" => 20
       },
       %{
         "lang" => "CSS",
-        "bytes" => 1_000,
         "percentage" => 10
       }
     ]
@@ -518,12 +505,10 @@ defmodule CoophubWeb.Fixtures do
     [
       %{
         "lang" => "PHP",
-        "bytes" => 90,
         "percentage" => 90
       },
       %{
         "lang" => "HTML",
-        "bytes" => 10,
         "percentage" => 10
       }
     ]


### PR DESCRIPTION
- Calculate the total of lang % using the aggregation of org lang %.
- Get rid of bytes where it is not needed. (bytes are only used to calculate % in github backend)
- Fix the index chart with the languages accumulating the org percentages