### PR TITLE
#57: Adding twitter meta image

### DIFF
--- a/lib/coophub_web/templates/layout/app.html.eex
+++ b/lib/coophub_web/templates/layout/app.html.eex
@@ -24,6 +24,7 @@
     <meta property="og:url" content="https://coophub.io" />
     <meta property="og:description" content="Open source projects and repositories from cooperatives around the world!" />
     <meta property="og:type" content="website" />
+    <meta property="twitter:image" content="https://coophub.io/images/logo-light.png" />
 
   </head>
   <body id="page-top">


### PR DESCRIPTION
This adds `meta` image for twitter links, see: #57 

I think summary card is not needed, this is just like now with image.