### PR TITLE
Support 0xacab

### DIFF
--- a/cooperatives.yml
+++ b/cooperatives.yml
@@ -669,3 +669,11 @@ reinblau:
   url: https://reinblau.coop/
   description: "Our cooperative has around 20 members spread across Germany. As a decentralized agency, we have a lot of experience working together in agile teams, even across geographical distances."
   location: Berlin, Germany
+
+sutty:
+  source: "0xacab"
+  login: "sutty"
+  name: "Sutty"
+  url: "https://sutty.coop.ar"
+  description: "A worker-owned cooperative developing and hosting resilient websites for collectives, non-profit organizations and activists."
+  location: "Argentina"

--- a/lib/coophub/backends/backends.ex
+++ b/lib/coophub/backends/backends.ex
@@ -33,7 +33,6 @@ defmodule Coophub.Backends do
   defp get_backend_module!("gitlab"), do: Backends.GitlabCom
   defp get_backend_module!("git.coop"), do: Backends.GitCoop
   defp get_backend_module!("0xacab"), do: Backends.HexAcab
-  defp get_backend_module!("hexacab"), do: Backends.HexAcab
   defp get_backend_module!(source), do: raise("Unknown backend source: #{source}")
 
   ########

--- a/lib/coophub/backends/backends.ex
+++ b/lib/coophub/backends/backends.ex
@@ -32,6 +32,8 @@ defmodule Coophub.Backends do
   defp get_backend_module!("github"), do: Backends.Github
   defp get_backend_module!("gitlab"), do: Backends.GitlabCom
   defp get_backend_module!("git.coop"), do: Backends.GitCoop
+  defp get_backend_module!("0xacab"), do: Backends.HexAcab
+  defp get_backend_module!("hexacab"), do: Backends.HexAcab
   defp get_backend_module!(source), do: raise("Unknown backend source: #{source}")
 
   ########

--- a/lib/coophub/backends/hex_acab.ex
+++ b/lib/coophub/backends/hex_acab.ex
@@ -1,0 +1,12 @@
+defmodule Coophub.Backends.HexAcab do
+  use Coophub.Backends.Gitlab
+
+  @spec name() :: String.t()
+  def name(), do: "0xacab.org"
+
+  def headers() do
+    []
+  end
+
+  def full_url(path), do: "https://0xacab.org/api/v4/#{path}"
+end


### PR DESCRIPTION
...and add Sutty :)

It may be related to #81 but I just copied the git.coop backend.  I couldn't test the UI because my node version seems to be too new and failed to start webpack, but after disabling it, `mix phx.server` retrieved our repos and I could see them on http://localhost:5000/api/repos