### PR TITLE
Add organization LibreSign from LibreCodeCoop

### DIFF
--- a/cooperatives.yml
+++ b/cooperatives.yml
@@ -254,6 +254,14 @@ librecode-gitlab:
   description: "LibreCode - Open source technology solutions"
   location: Brazil
 
+libresign:
+  source: github
+  login: libresign
+  name: LibreCode Coop
+  url: http://libresign.coop/
+  description: "LibreCode - Open source technology solutions"
+  location: Brazil
+
 bagimsizatolye:
   source: gitlab
   login: bagimsizatolye


### PR DESCRIPTION
LibreSign is a specific organization owned by LibreCode Coop and created to have all repositories related to LibreSign project.

LibreSign is a web FLOSS software created to do digital signatures on PDF files and other kind of files.

Ref: https://github.com/fiqus/coophub/issues/88